### PR TITLE
HMR for svelte native

### DIFF
--- a/lib/hot/hot-api.js
+++ b/lib/hot/hot-api.js
@@ -1,4 +1,6 @@
 import { initProxy } from './proxy';
+import DomAdapter from './proxy-adapter-dom';
+import NativeAdapter from './proxy-adapter-native';
 
 const defaultHotOptions = {
 	noPreserveState: false,
@@ -6,7 +8,12 @@ const defaultHotOptions = {
 
 const registry = new Map();
 
-const createProxy = initProxy();
+
+// The first time we are called, we determine whether we are for native or web and initialize the createProxy function
+let createProxy = function(id, component, hotOptions) {
+	createProxy = initProxy(hotOptions.native ? NativeAdapter : DomAdapter);
+	return createProxy(id, component, hotOptions);
+};
 
 // One stop shop for HMR updates. Combines functionality of `configure`,
 // `register`, and `reload`, based on current registry state.

--- a/lib/hot/patch-page-show-modal.js
+++ b/lib/hot/patch-page-show-modal.js
@@ -1,0 +1,63 @@
+/* global Symbol */
+
+// This module monkey patches Page#showModal in order to be able to
+// access from the HMR proxy data passed to `showModal` in svelte-native.
+//
+// Data are stored in a opaque prop accessible with `getModalData`.
+//
+// It also switches the `closeCallback` option with a custom brewed one
+// in order to give the proxy control over when its own instance will be
+// destroyed.
+//
+// Obviously this method suffer from extreme coupling with the target code
+// in svelte-native. So it would be wise to recheck compatibility on SN
+// version upgrades.
+//
+// Relevant code is there (last checked version):
+//
+// https://github.com/halfnelson/svelte-native/blob/08702e6b178644f43052f6ec0a789a51e800d21b/src/dom/svelte/StyleElement.ts
+//
+
+// FIXME should we override ViewBase#showModal instead?
+import { Page } from 'tns-core-modules/ui/page';
+
+const prop =
+	typeof Symbol !== 'undefined'
+		? Symbol('hmr_svelte_native_modal')
+		: '___HMR_SVELTE_NATIVE_MODAL___';
+
+const sup = Page.prototype.showModal;
+
+let patched = false;
+
+export const patchShowModal = () => {
+	// guard: already patched
+	if (patched) return;
+	patched = true;
+
+	Page.prototype.showModal = function(modalView, options) {
+		const modalData = {
+			originalOptions: options,
+			closeCallback: options.closeCallback,
+		};
+
+		modalView[prop] = modalData;
+
+		// Proxies to a function that can be swapped on the fly by HMR proxy.
+		//
+		// The default is still to call the original closeCallback from svelte
+		// navtive, which will destroy the modal view & component. This way, if
+		// no HMR happens on the modal content, normal behaviour is preserved
+		// without the proxy having any work to do.
+		//
+		const closeCallback = (...args) => {
+			return modalData.closeCallback(...args);
+		};
+
+		const temperedOptions = Object.assign({}, options, { closeCallback });
+
+		return sup.call(this, modalView, temperedOptions);
+	};
+};
+
+export const getModalData = modalView => modalView[prop];

--- a/lib/hot/proxy-adapter-native.js
+++ b/lib/hot/proxy-adapter-native.js
@@ -1,0 +1,303 @@
+/* global document */
+
+import ProxyAdapterDom from './proxy-adapter-dom';
+
+import { getModalData } from './patch-page-show-modal';
+
+// Svelte Native support
+// =====================
+//
+// Rerendering Svelte Native page proves challenging...
+//
+// In NativeScript, pages are the top level component. They are normally
+// introduced into NativeScript's runtime by its `navigate` function. This
+// is how Svelte Natives handles it: it renders the Page component to a
+// dummy fragment, and "navigate" to the page element thus created.
+//
+// As long as modifications only impact child components of the page, then
+// we can keep the existing page and replace its content for HMR.
+//
+// However, if the page component itself is modified (including its system
+// title bar), things get hairy...
+//
+// Apparently, the sole way of introducing a new page in a NS application is
+// to navigate to it (no way to just replace it in its parent "element", for
+// example). This is how it is done in NS's own "core" HMR.
+//
+// Unfortunately the API they're using to do that is not public... Its various
+// parts remain exposed though (but documented as private), so this exploratory
+// work now relies on it. It might be fragile...
+//
+// The problem is that there is no public API that can navigate to a page and
+// replacing (like location.replace) the current history entry. Actually there
+// is an active issue at NS asking for that. Incidentally, members of
+// NativeScript-Vue have commented on the issue to weight in for it -- they
+// probably face some similar challenge.
+
+// svelte-native uses navigateFrom event + e.isBackNavigation to know
+// when to $destroy the component -- but we don't want our proxy instance
+// destroyed when we renavigate to the same page for navigation purposes!
+const interceptPageNavigation = pageElement => {
+	const originalNativeView = pageElement.nativeView;
+	const { on } = originalNativeView;
+	const ownOn = originalNativeView.hasOwnProperty('on');
+	// tricks svelte-native into giving us its handler
+	originalNativeView.on = function(type, handler, ...rest) {
+		if (type === 'navigatedFrom') {
+			this.navigatedFromHandler = handler;
+			if (ownOn) {
+				originalNativeView.on = on;
+			} else {
+				delete originalNativeView.on;
+			}
+		} else {
+			throw new Error(
+				'Unexpected call: has underlying svelte-native code changed?'
+			);
+		}
+	};
+};
+
+const getNavTransition = ({ transition }) => {
+	if (typeof transition === 'string') {
+		transition = { name: transition };
+	}
+	return transition ? { animated: true, transition } : { animated: false };
+};
+
+export default class ProxyAdapterNative extends ProxyAdapterDom {
+	constructor(instance) {
+		super(instance);
+
+		this.nativePageElement = null;
+		this.originalNativeView = null;
+		this.navigatedFromHandler = null;
+
+		this.relayNativeNavigatedFrom = this.relayNativeNavigatedFrom.bind(this);
+	}
+
+	dispose() {
+		super.dispose();
+		this.releaseNativePageElement();
+	}
+
+	releaseNativePageElement() {
+		if (this.nativePageElement) {
+			// native cleaning will happen when navigating back from the page
+			this.nativePageElement = null;
+		}
+	}
+
+	afterMount(target, anchor) {
+		// nativePageElement needs to be updated each time (only for page
+		// components, native component that are not pages follow normal flow)
+		//
+		// DEBUG quid of components that are initially a page, but then have the
+		// <page> tag removed while running? or the opposite?
+		//
+		// insertionPoint needs to be updated _only when the target changes_ --
+		// i.e. when the component is mount, i.e. (in svelte3) when the component
+		// is _created_, and svelte3 doesn't allow it to move afterward -- that
+		// is, insertionPoint only needs to be created once when the component is
+		// first mounted.
+		//
+		// DEBUG is it really true that components' elements cannot move in the
+		// DOM? what about keyed list?
+		//
+		const isNativePage = target.tagName === 'fragment';
+		if (isNativePage) {
+			const nativePageElement = target.firstChild;
+			interceptPageNavigation(nativePageElement);
+			this.nativePageElement = nativePageElement;
+		} else {
+			// try to protect against components changing from page to no-page
+			// or vice versa -- see DEBUG 1 above. NOT TESTED so prolly not working
+			this.nativePageElement = null;
+			super.afterMount(target, anchor);
+		}
+	}
+
+	rerender() {
+		const { nativePageElement } = this;
+		if (nativePageElement) {
+
+			this.rerenderNative();
+		} else {
+			super.rerender();
+		}
+	}
+
+	rerenderNative() {
+		const { nativePageElement: oldPageElement } = this;
+		const nativeView = oldPageElement.nativeView;
+		const frame = nativeView.frame;
+		if (frame) {
+			return this.rerenderPage(frame, nativeView);
+		}
+		const modalParent = nativeView._modalParent; // FIXME private API
+		if (modalParent) {
+			return this.rerenderModal(modalParent, nativeView);
+		}
+		// wtf? hopefully a race condition with a destroyed component, so
+		// we have nothing more to do here
+		//
+		// for once, it happens when hot reloading dev deps, like this file
+		//
+	}
+
+	rerenderPage(frame, previousPageView) {
+		const isCurrentPage = frame.currentPage === previousPageView;
+		if (isCurrentPage) {
+			const {
+				instance: { hotOptions },
+			} = this;
+			const newPageElement = this.createPage();
+			if (!newPageElement) {
+				throw new Error('Failed to create updated page');
+			}
+			const isFirstPage = !frame.canGoBack();
+
+			if (isFirstPage) {
+				// The "replacePage" strategy does not work on the first page
+				// of the stack.
+				//
+				// Resulting bug:
+				// - launch
+				// - change first page => HMR
+				// - navigate to other page
+				// - back
+				//   => actual: back to OS
+				//   => expected: back to page 1
+				//
+				// Fortunately, we can overwrite history in this case.
+				//
+				const nativeView = newPageElement.nativeView;
+				frame.navigate(
+					Object.assign(
+						{},
+						{
+							create: () => nativeView,
+							clearHistory: true,
+						},
+						getNavTransition(hotOptions)
+					)
+				);
+			} else {
+				// copied from TNS FrameBase.replacePage
+				//
+				// it is not public but there is a comment in there indicating
+				// it is for HMR (probably their own core HMR though)
+				//
+				// frame.navigationType = NavigationType.replace;
+				const currentBackstackEntry = frame._currentEntry;
+				frame.navigationType = 2;
+				frame.performNavigation({
+					isBackNavigation: false,
+					entry: {
+						resolvedPage: newPageElement.nativeView,
+						//
+						// entry: currentBackstackEntry.entry,
+						entry: Object.assign(
+							currentBackstackEntry.entry,
+							getNavTransition(hotOptions)
+						),
+						navDepth: currentBackstackEntry.navDepth,
+						fragmentTag: currentBackstackEntry.fragmentTag,
+						frameId: currentBackstackEntry.frameId,
+					},
+				});
+			}
+		} else {
+			const backEntry = frame.backStack.find(
+				({ resolvedPage: page }) => page === previousPageView
+			);
+			if (!backEntry) {
+				// well... looks like we didn't make it to history after all
+				return;
+			}
+			// replace existing nativeView
+			const newPageElement = this.createPage();
+			if (newPageElement) {
+				backEntry.resolvedPage = newPageElement.nativeView;
+			} else {
+				throw new Error('Failed to create updated page');
+			}
+		}
+	}
+
+	// modalParent is the page on which showModal(...) was called
+	// oldPageElement is the modal content, that we're actually trying to reload
+	rerenderModal(modalParent, modalView) {
+		const modalData = getModalData(modalView);
+
+		modalData.closeCallback = () => {
+			const nativePageElement = this.createPage();
+			if (!nativePageElement) {
+				throw new Error('Failed to created updated modal page');
+			}
+			const { nativeView } = nativePageElement;
+			const { originalOptions } = modalData;
+			// Options will get monkey patched again, the only work left for us
+			// is to try to reduce visual disturbances.
+			//
+			// FIXME Even that proves too much unfortunately... Apparently TNS
+			// does not respect the `animated` option in this context:
+			// https://docs.nativescript.org/api-reference/interfaces/_ui_core_view_base_.showmodaloptions#animated
+			//
+			const options = Object.assign({}, originalOptions, { animated: false });
+			modalParent.showModal(nativeView, options);
+		};
+
+		modalView.closeModal();
+	}
+
+	createPage() {
+		const {
+			instance: { refreshComponent },
+		} = this;
+		const { nativePageElement, relayNativeNavigatedFrom } = this;
+		const oldNativeView = nativePageElement.nativeView;
+		// rerender
+		const target = document.createElement('fragment');
+		let haveNewPage = false;
+		//if the old page was destroyed then we can be sure we have a new page element.
+		refreshComponent(target, null, () => { haveNewPage = true; });
+		if (!haveNewPage) return;
+
+		this.releaseNativePageElement();
+		this.afterMount(target); // udpates nativePageElement
+		const newPageElement = this.nativePageElement;
+		// update event proxy
+		oldNativeView.off('navigatedFrom', relayNativeNavigatedFrom);
+		nativePageElement.nativeView.on('navigatedFrom', relayNativeNavigatedFrom);
+		return newPageElement;
+	}
+
+	relayNativeNavigatedFrom({ isBackNavigation }) {
+		const { originalNativeView, navigatedFromHandler } = this;
+		if (!isBackNavigation) {
+			return;
+		}
+		if (originalNativeView) {
+			const { off } = originalNativeView;
+			const ownOff = originalNativeView.hasOwnProperty('off');
+			originalNativeView.off = function() {
+				this.navigatedFromHandler = null;
+				if (ownOff) {
+					originalNativeView.off = off;
+				} else {
+					delete originalNativeView.off;
+				}
+			};
+		}
+		if (navigatedFromHandler) {
+			return navigatedFromHandler.apply(this, arguments);
+		}
+	}
+
+	renderError(err, target, anchor) {
+		// TODO fallback on TNS error handler for now... at least our error
+		// is more informative
+		throw err;
+	}
+}

--- a/lib/hot/proxy.js
+++ b/lib/hot/proxy.js
@@ -1,4 +1,4 @@
-import DomAdapter from './proxy-adapter-dom';
+
 import { hookComponent, restoreState, captureState } from './svelte-hooks';
 
 const handledMethods = ['constructor', '$destroy'];
@@ -345,7 +345,7 @@ decorates the original component with trackers
 and ensures resolution to the
 latest version of the component
 */
-export const initProxy = (Adapter = DomAdapter) =>
+export const initProxy = (Adapter) =>
 	function createProxy(id, component, hotOptions) {
 		const debugName = getDebugName(id);
 		const instances = [];

--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -12,7 +12,9 @@ function VirtualModulesPlugin(compiler) {
 		var originalPurge = compiler.inputFileSystem.purge;
 
 		compiler.inputFileSystem.purge = function() {
-			originalPurge.call(this, arguments);
+			if (originalPurge) {
+				originalPurge.call(this, arguments);
+			}
 			if (this._virtualFiles) {
 				Object.keys(this._virtualFiles).forEach(
 					function(file) {


### PR DESCRIPTION
Just added back the two native adapter files from svelte-dev-helper, updated refreshComponent for the new signature, delayed creation of the createProxy function until we had a copy of `hotOptions`